### PR TITLE
Update dependencies to fix a vulnerability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["authentication", "cryptography"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hex-literal = "0.2.1"
-aes = "0.3.2"
-aes-soft = "0.3.3"
-block-modes = "0.3.3"
+hex-literal = "0.3.1"
+aes = "0.6.0"
+aes-soft = "0.6.4"
+block-modes = "0.7.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,8 +37,8 @@ extern crate block_modes;
 #[cfg_attr(test, macro_use)]
 extern crate hex_literal;
 
-use aes::block_cipher_trait::generic_array::GenericArray;
-use aes::block_cipher_trait::BlockCipher;
+use aes::cipher::generic_array::GenericArray;
+use aes::cipher::BlockCipher;
 use aes::Aes128;
 
 /// xor two 16 bytes array
@@ -241,6 +241,8 @@ impl Milenage {
     }
 
     fn rijndael_encrypt(&self, input: &[u8; 16]) -> [u8; 16] {
+        use crate::aes::cipher::NewBlockCipher;
+
         let key = GenericArray::from_slice(&self.k);
         let cipher = Aes128::new(key);
         let mut block = GenericArray::clone_from_slice(input);


### PR DESCRIPTION
Hi, I've submitted this Pull Request, because of a security vulnerability found by cargo-audit for this crate.  
More specifically - it's the `generic-array` crate issue - more details [here](https://rustsec.org/advisories/RUSTSEC-2020-0146)

I've updated all the dependencies in the crate in order to use the `generic-array` version without the vulnerability above.
No major changes were needed.

I'd appreciate if you could check this PR. 
Could you also publish a new version of the crate if the changes will be merged in?