### PR TITLE
Add Cargo features and code to allow OpenSSL to be used for Crypto

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Build
+    - name: Build default (AES)
       run: cargo build --verbose
-    - name: Run tests
+    - name: Build explicit AES
+      run: cargo build --verbose --no-default-features --features aes
+    - name: Build explicit OpenSSL
+      run: cargo build --verbose --no-default-features --features openssl
+    - name: Run default tests (AES)
       run: cargo test --verbose
+    - name: Run explicit AES tests
+      run: cargo test --verbose --no-default-features --features aes
+    - name: Run explicit OpenSSL tests
+      run: cargo test --verbose --no-default-features --features openssl

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,14 @@ categories = ["authentication", "cryptography"]
 
 [dependencies]
 hex-literal = "0.3.1"
-aes = "0.6.0"
-aes-soft = "0.6.4"
-block-modes = "0.7.0"
 sha2 = "0.9.3"
 hmac = "0.10.1"
+openssl = { version = "0.10", optional = true }
+aes = { version = "0.6.0", optional = true }
+aes-soft = { version = "0.6.4", optional = true }
+block-modes = { version = "0.7.0", optional = true }
+
+[features]
+default = ["aes"]
+openssl = ["dep:openssl"]
+aes = ["dep:aes", "dep:aes-soft", "dep:block-modes"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -405,7 +405,7 @@ mod tests {
         let (res, _, _, _) = m.f2345(&rand);
         match m.compute_res_star("001", "01", &rand, &res) {
             Ok(res_star) => assert_eq!(res_star, hex!("f236a7417272bfb2d66d4d670733b527")),
-            Err(e) => panic!(e),
+            Err(e) => panic!("{}", e),
         };
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //!
 //!        let mut m = Milenage::new_with_op(k, op);
 //!        let (res, ck, ik, ak) = m.f2345(&rand);
-//!        
+//!
 //!        assert_eq!(m.res.unwrap(), hex!("a54211d5e3ba50bf"));
 //!        // or
 //!        assert_eq!(res, hex!("a54211d5e3ba50bf"));
@@ -32,14 +32,30 @@
 //!
 //! ```
 
-extern crate aes_soft as aes;
-extern crate block_modes;
+#[cfg(all(feature = "aes", feature = "openssl"))]
+compile_error!("feature \"aes\" and feature \"openssl\" cannot be enabled at the same time");
+
 #[cfg_attr(test, macro_use)]
 extern crate hex_literal;
 
-use aes::cipher::generic_array::GenericArray;
-use aes::cipher::BlockCipher;
-use aes::Aes128;
+#[cfg(feature = "aes")]
+extern crate aes_soft as aes;
+#[cfg(feature = "aes")]
+extern crate block_modes;
+
+#[cfg(feature = "aes")]
+use {
+    aes::cipher::generic_array::GenericArray,
+    aes::cipher::BlockCipher,
+    aes::Aes128,
+};
+
+#[cfg(feature = "openssl")]
+use {
+    openssl::aes::{AesKey, aes_ige},
+    openssl::symm::Mode,
+};
+
 use sha2::Sha256;
 use hmac::{Hmac, Mac, NewMac};
 
@@ -294,6 +310,7 @@ impl Milenage {
         self.opc = xor(&ciphered_opc, &op);
     }
 
+    #[cfg(feature = "aes")]
     fn rijndael_encrypt(&self, input: &[u8; 16]) -> [u8; 16] {
         use crate::aes::cipher::NewBlockCipher;
 
@@ -303,6 +320,17 @@ impl Milenage {
         cipher.encrypt_block(&mut block);
         let mut output = [0u8; 16];
         output.copy_from_slice(&block);
+
+        output
+    }
+
+    #[cfg(feature = "openssl")]
+    fn rijndael_encrypt(&self, input: &[u8; 16]) -> [u8; 16] {
+        let key = AesKey::new_encrypt(&self.k).unwrap();
+        let mut iv = [0;32];
+        let mut output = [0u8; 16];
+        aes_ige(input, &mut output, &key, &mut iv, Mode::Encrypt);
+
         output
     }
 }


### PR DESCRIPTION
Hi - thanks for sharing this library!

This change is to add support for using OpenSSL for cryptography instead of the AES crate - for cases where only a trusted OpenSSL implementation is supported for anything cryptography related. There's no functional change to the output of the library.

I've added this as a cargo feature so that the AES crate is still used by default so as not to impact existing users who don't want the OpenSSL dependency. Using one feature doesn't compile in the dependencies of the other.

I've also added extra workflow steps to test the two feature options explicitly, and confirmed these pass.

Let me know if you have any comments. 

If you do accept, would you be able to tag a new release as well please?

Thanks again!